### PR TITLE
修复优酷未正确解析出弹幕颜色的问题

### DIFF
--- a/routes/api/youku.mjs
+++ b/routes/api/youku.mjs
@@ -143,8 +143,9 @@ export default class YoukuSource extends BaseSource {
       for (const danmu of danmus) {
         const content = JSON.parse(JSON.stringify(this.content_template));
         content.timepoint = danmu['playat'] / 1000;
-        if (danmu.propertis.color) {
-          content.color = JSON.parse(danmu.propertis).color;
+        const propertis = JSON.parse(danmu.propertis);
+        if (propertis.color) {
+          content.color = propertis.color;
         }
         content.content = danmu.content;
         contents.push(content);


### PR DESCRIPTION
danmu.propertis 是一个JSON字符串，if (danmu.propertis.color) 永远也不可能成立，必须先解析再判断


另外 propertis 其实是个错误拼写，正确的应该是 properties，
它接口返回的是错误拼写🤣，我们本地变量名也只好跟它保持一致了